### PR TITLE
Re-create folder structure based on prefix

### DIFF
--- a/s3dl/s3dl.py
+++ b/s3dl/s3dl.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 from concurrent import futures
+from distutils.dir_util import mkpath
 import argparse
 import collections
 import functools
@@ -185,9 +186,10 @@ class DownloadInfo(object):
         if '@' in bucket:
             bucket = bucket.split('@')[-1]
 
-        # Filename
-        filename = key.split('/')[-1]
-        file_path = os.path.join(download_directory, filename)
+        dir_path = os.path.join(download_directory, bucket, *key.split('/')[:-1])
+        mkpath(dir_path)
+
+        file_path = os.path.join(download_directory, bucket, key)
 
         return cls(bucket, key, file_path, no_clobber)
 


### PR DESCRIPTION
Currently s3dl download all the files into same folder, ignoring prefix. That may cause a lot of duplication in some case.
This update will re-create folder structure based on prefix, with default delimiter ('/')